### PR TITLE
Changed MongoDB Java Driver from 2.11.3 to 3.6.1

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -45,7 +45,7 @@ For a more complete configuration, here is the full set of options with all of t
        roleNameField="name"/>
 ----
 
-The syntax of mongoClientURI can be found here: http://api.mongodb.org/java/2.11.3/com/mongodb/MongoClientURI.html - through this variable you can configure the MongoRealm to connect to multiple MongoDB instances in a replicaSet.  You can configure timeouts, wait queue timeouts, read preferences (primary or secondary), authentication option for the connection to MongoDB.
+The syntax of mongoClientURI can be found here: http://api.mongodb.com/java/current/com/mongodb/MongoClientURI.html - through this variable you can configure the MongoRealm to connect to multiple MongoDB instances in a replicaSet.  You can configure timeouts, wait queue timeouts, read preferences (primary or secondary), authentication option for the connection to MongoDB.
         
 
 == Design Goals

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>2.11.3</version>
+    		<artifactId>mongo-java-driver</artifactId>
+    		<version>3.6.1</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
The **MongoDB Java Driver 2.11.3** used in _pom.xml_, was causing the error `Error: 18 { ok: 0.0, errmsg: "auth failed", code: 18 }` when connecting to a remote [mLab](https://mlab.com) repository. Starting with **version 3.0**, the default authentication mechanism is _SCRAM-SHA-1_, which the previous versions of mongo shell do not support, hence the failed authentication. The driver is outdated, so the _pom.xml_ was updated with the latest version - **MongoDB Java Driver 3.6.1**.

Also, the URL for the _MongoClientURI_ documentation was updated with the latest one.